### PR TITLE
fix: remove [ ] from state initialization to avoid passing a whole ar…

### DIFF
--- a/src/components/formProducts/FormProducts.js
+++ b/src/components/formProducts/FormProducts.js
@@ -8,7 +8,7 @@ const FormProducts = ({ items }) => {
   const [itemName, setItemName] = useState('');
   const handleChange = (e) => setItemName(e.target.value);
   const token = useRef(getTokenFromStorage());
-  const [itemsFiltered, setItemsFiltered] = useState([items]);
+  const [itemsFiltered, setItemsFiltered] = useState(items);
 
   useEffect(() => {
     if (itemName === '') {


### PR DESCRIPTION
…ray instead of single item to ProductForList.

## Description

Esta PR arregla el bug causado al tratar de renderizar la lista. La causa era los [ ] que había al inicializar el state y que hacían que en un primer momento se le pasara al componente ProductForList un array de objetos en vez de un objeto. Debido a esto tratar de leer la propiedad lastPurchase (y luego aplicarle el método .toDate()) en el array generaba el error.

## Related Issue

Closes #27 

## Acceptance Criteria

NA

## Type of Changes



|     | Type                       |
| --- | -------------------------- |
|   ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/63521762/154530445-756ab14e-5129-460d-83cf-fb5f7733cdbf.png)


