### PR TITLE
fix: setInitialItems verifica que sí haya un array items en data.

### DIFF
--- a/src/pages/List/List_Products.js
+++ b/src/pages/List/List_Products.js
@@ -24,14 +24,18 @@ const ListProducts = () => {
       const setInitialItems = (token) => {
         unsub = onSnapshot(doc(db, 'lists', token.current), (doc) => {
           const data = doc.data();
+          const { items } = data;
+
           if (data === undefined) {
             setItems([]);
             localStorage.removeItem('token');
             navigate('/');
+          } else if (!items) {
+            setItems([]);
           } else {
-            let { items } = doc.data();
             setItems(items);
           }
+
           setLoading(false);
         });
       };
@@ -45,6 +49,7 @@ const ListProducts = () => {
       }
     };
   }, [navigate]);
+
   if (!token.current) return <Redirection />;
 
   return (


### PR DESCRIPTION
## Description

* Se estaba generando un error que crasheaba la aplicación si el usuario navegaba a List justo después dar clic en 'Create a new list'.
* El error se debía a que en ese momento el documento de la base de datos existía (entonces aprobaba la condición de la función `setInitialItems`) pero no tenía una propiedad llamada `items`.
*Añadiendo una condición para verificar esto se arregla. La solución de Fauricio también funcionaba muy bien pero sólo si el usuario no usaba el filtro de búsqueda.



## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |
|    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |



## Testing Steps / QA Criteria
* Ir a la aplicación y crear una nueva lista.
* Al hacer esto, la aplicación lleva directamente a 'Add items', navegar a 'List' y comprobar que no haya errores.

